### PR TITLE
Support alternative parameters for checking if DLSS is available and modifying width/height

### DIFF
--- a/CyberFSR/Dx12ParameterImpl.cpp
+++ b/CyberFSR/Dx12ParameterImpl.cpp
@@ -49,6 +49,12 @@ void Dx12ParameterImpl::Set(const char* InName, int InValue)
 	case Util::NvParameter::Height:
 		Height = InValue;
 		break;
+	case Util::NvParameter::DLSS_Render_Subrect_Dimensions_Width:
+		Width = InValue;
+		break;
+	case Util::NvParameter::DLSS_Render_Subrect_Dimensions_Height:
+		Height = InValue;
+		break;
 	case Util::NvParameter::PerfQualityValue:
 		PerfQualityValue = static_cast<NVSDK_NGX_PerfQuality_Value>(InValue);
 		break;
@@ -164,12 +170,21 @@ NVSDK_NGX_Result Dx12ParameterImpl::Get(const char* InName, int* OutValue) const
 	case Util::NvParameter::SuperSampling_Available:
 		*OutValue = 1;
 		break;
+	case Util::NvParameter::SuperSampling_FeatureInitResult:
+		*OutValue = 1;
+		break;
 	case Util::NvParameter::SuperSampling_NeedsUpdatedDriver:
 		*OutValue = FALSE;
 		break;
 	case Util::NvParameter::SuperSampling_MinDriverVersionMinor:
 	case Util::NvParameter::SuperSampling_MinDriverVersionMajor:
 		*OutValue = 0;
+		break;
+	case Util::NvParameter::DLSS_Render_Subrect_Dimensions_Width:
+		*OutValue = Width;
+		break;
+	case Util::NvParameter::DLSS_Render_Subrect_Dimensions_Height:
+		*OutValue = Height;
 		break;
 	case Util::NvParameter::OutWidth:
 		*OutValue = OutWidth;

--- a/CyberFSR/Util.cpp
+++ b/CyberFSR/Util.cpp
@@ -39,6 +39,8 @@ Util::NvParameter Util::NvParameterToEnum(const char* name)
 	{"OutWidth", NvParameter::OutWidth},
 	{"OutHeight", NvParameter::OutHeight},
 
+	{"DLSS.Render.Subrect.Dimensions.Width", NvParameter::DLSS_Render_Subrect_Dimensions_Width},
+	{"DLSS.Render.Subrect.Dimensions.Height", NvParameter::DLSS_Render_Subrect_Dimensions_Height},
 	{"DLSS.Get.Dynamic.Max.Render.Width", NvParameter::DLSS_Get_Dynamic_Max_Render_Width},
 	{"DLSS.Get.Dynamic.Max.Render.Height", NvParameter::DLSS_Get_Dynamic_Max_Render_Height},
 	{"DLSS.Get.Dynamic.Min.Render.Width", NvParameter::DLSS_Get_Dynamic_Min_Render_Width},

--- a/CyberFSR/Util.h
+++ b/CyberFSR/Util.h
@@ -24,6 +24,8 @@ public:
 		OutWidth,
 		OutHeight,
 
+		DLSS_Render_Subrect_Dimensions_Width,
+		DLSS_Render_Subrect_Dimensions_Height,
 		DLSS_Get_Dynamic_Max_Render_Width,
 		DLSS_Get_Dynamic_Max_Render_Height,
 		DLSS_Get_Dynamic_Min_Render_Width,


### PR DESCRIPTION
As I mentioned in my previous comment (https://github.com/PotatoOfDoom/CyberFSR2/issues/2#issuecomment-1170843527), Dying Light 2 checks `SuperSampling.FeatureInitResult` to see if DLSS is available and modifies `DLSS.Render.Subrect.Dimensions.Width`/`DLSS.Render.Subrect.Dimensions.Height` to change the width/height.

This PR adds the new parameters to the `NvParamTranslation` map and handles them in the appropriate switch statements. With these changes, any game that uses these parameters will have the corresponding variables set instead of being silently ignored.

Note: while this is a start to supporting multiple games, it isn't sufficient since `ViewMatrixHook` will still need to have default values when it can't access a game's memory directly.

