### PR TITLE
Recognize sharpness parameter

### DIFF
--- a/CyberFSR/Util.cpp
+++ b/CyberFSR/Util.cpp
@@ -43,6 +43,7 @@ Util::NvParameter Util::NvParameterToEnum(const char* name)
 	{"DLSS.Get.Dynamic.Max.Render.Height", NvParameter::DLSS_Get_Dynamic_Max_Render_Height},
 	{"DLSS.Get.Dynamic.Min.Render.Width", NvParameter::DLSS_Get_Dynamic_Min_Render_Width},
 	{"DLSS.Get.Dynamic.Min.Render.Height", NvParameter::DLSS_Get_Dynamic_Min_Render_Height},
+	{"Sharpness", NvParameter::Sharpness},
 
 	{"DLSSOptimalSettingsCallback", NvParameter::DLSSOptimalSettingsCallback},
 	{"DLSSGetStatsCallback", NvParameter::DLSSGetStatsCallback},


### PR DESCRIPTION
Although `Sharpness` is a valid value for `NvParameter`, it is never reached in the switch statements because the `NvParamTranslation` map is missing an entry with a "Sharpness" key. The `Dx12ParameterImpl::Sharpness` field is [initialized to `1.0f`](https://github.com/PotatoOfDoom/CyberFSR2/blob/416e58348fc88286198553b986a58411f556323a/CyberFSR/Dx12ParameterImpl.h#L7), which means that FSR would always run with a full sharpness value. 

In this PR, I add this parameter to the map to allow the Sharpness field to be modified. 

Surprisingly, the sharpness in Cyberpunk already appears to change without this PR. I believe Cyberpunk is using an additional sharpening post-processing effect _after_ the FSR stage which caused the missing Sharpness entry to be overlooked. However, in Dying Light 2, the image sharpness previously did not change regardless of the in-game sharpness slider. I can confirm that this PR enables a changing sharpness value in that game.