### PR TITLE
Null checks for exposureTexture and inputBiasColorMask

### DIFF
--- a/CyberFSR/CyberFsrVk.cpp
+++ b/CyberFSR/CyberFsrVk.cpp
@@ -168,8 +168,16 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_VULKAN_EvaluateFeature(VkCom
 	dispatchParameters.color = ffxGetTextureResourceVK(fsrContext, color->Resource.ImageViewInfo.Image, color->Resource.ImageViewInfo.ImageView, color->Resource.ImageViewInfo.Width, color->Resource.ImageViewInfo.Height, color->Resource.ImageViewInfo.Format, (wchar_t*)L"FSR2_InputColor");
 	dispatchParameters.depth = ffxGetTextureResourceVK(fsrContext, depth->Resource.ImageViewInfo.Image, depth->Resource.ImageViewInfo.ImageView, depth->Resource.ImageViewInfo.Width, depth->Resource.ImageViewInfo.Height, depth->Resource.ImageViewInfo.Format, (wchar_t*)L"FSR2_InputDepth");
 	dispatchParameters.motionVectors = ffxGetTextureResourceVK(fsrContext, motionVectors->Resource.ImageViewInfo.Image, motionVectors->Resource.ImageViewInfo.ImageView, motionVectors->Resource.ImageViewInfo.Width, motionVectors->Resource.ImageViewInfo.Height, motionVectors->Resource.ImageViewInfo.Format, (wchar_t*)L"FSR2_InputMotionVectors");
-	dispatchParameters.exposure = ffxGetTextureResourceVK(fsrContext, exposureTexture->Resource.ImageViewInfo.Image, exposureTexture->Resource.ImageViewInfo.ImageView, exposureTexture->Resource.ImageViewInfo.Width, exposureTexture->Resource.ImageViewInfo.Height, exposureTexture->Resource.ImageViewInfo.Format, (wchar_t*)L"FSR2_InputExposure");
-	dispatchParameters.reactive = ffxGetTextureResourceVK(fsrContext, inputBiasColorMask->Resource.ImageViewInfo.Image, inputBiasColorMask->Resource.ImageViewInfo.ImageView, inputBiasColorMask->Resource.ImageViewInfo.Width, inputBiasColorMask->Resource.ImageViewInfo.Height, inputBiasColorMask->Resource.ImageViewInfo.Format, (wchar_t*)L"FSR2_InputReactiveMap");
+	
+	if (exposureTexture == nullptr)
+		dispatchParameters.exposure = ffxGetTextureResourceVK(fsrContext, nullptr, nullptr, 1, 1, VK_FORMAT_UNDEFINED, (wchar_t*)L"FSR2_InputExposure");
+	else
+		dispatchParameters.exposure = ffxGetTextureResourceVK(fsrContext, exposureTexture->Resource.ImageViewInfo.Image, exposureTexture->Resource.ImageViewInfo.ImageView, exposureTexture->Resource.ImageViewInfo.Width, exposureTexture->Resource.ImageViewInfo.Height, exposureTexture->Resource.ImageViewInfo.Format, (wchar_t*)L"FSR2_InputExposure");
+
+	if (inputBiasColorMask == nullptr)
+		dispatchParameters.reactive = ffxGetTextureResourceVK(fsrContext, nullptr, nullptr, 1, 1, VK_FORMAT_UNDEFINED, (wchar_t*)L"FSR2_InputReactiveMap");
+	else
+		dispatchParameters.reactive = ffxGetTextureResourceVK(fsrContext, inputBiasColorMask->Resource.ImageViewInfo.Image, inputBiasColorMask->Resource.ImageViewInfo.ImageView, inputBiasColorMask->Resource.ImageViewInfo.Width, inputBiasColorMask->Resource.ImageViewInfo.Height, inputBiasColorMask->Resource.ImageViewInfo.Format, (wchar_t*)L"FSR2_InputReactiveMap");
 	
 	if (transparencyMask == nullptr)
 		dispatchParameters.transparencyAndComposition = ffxGetTextureResourceVK(fsrContext, nullptr, nullptr, 1, 1, VK_FORMAT_UNDEFINED, (wchar_t*)L"FSR2_TransparencyAndCompositionMap");


### PR DESCRIPTION
nullptr checks for exposureTexture and inputBiasColorMask to prevent dereferencing of null pointers during passing parameters to ffxGetTextureResourceVK, which leads to some Vulkan game crashes (in particular, No Man's Sky and Baldur's Gate III as reported by @TheRazerMD)