### PR TITLE
Add Support for Rise of the Tomb Raider

### DIFF
--- a/CyberFSR/CyberFsrDx11.cpp
+++ b/CyberFSR/CyberFsrDx11.cpp
@@ -1,0 +1,18 @@
+#include "pch.h"
+#include "CyberFsr.h"
+
+NVSDK_NGX_Result NVSDK_NGX_D3D11_Init(void)
+{
+	return NVSDK_NGX_Result_Success;
+}
+
+NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_D3D11_Shutdown(void)
+{
+	return NVSDK_NGX_Result_Success;
+}
+
+NVSDK_NGX_Result NVSDK_NGX_D3D11_GetParameters(NVSDK_NGX_Parameter** OutParameters)
+{
+	*OutParameters = CyberFsrContext::instance()->AllocateParameter();
+	return NVSDK_NGX_Result_Success;
+}


### PR DESCRIPTION
Required to make DLSS2FSR working properly on Rise of the Tomb Raider

@lnfecteDru
"In addition to the GPU check, RoTTR checks for D3D11 DLSS support as well (regardless of chosen graphics API). Basically, it checks if D3D11 DLSS functions exist, gets parameters from GetParameters and shuts down DLSS. So stub functions for Init, GetParameters and Shutdown is enough."

Source for Reference: https://github.com/PotatoOfDoom/CyberFSR2/issues/32

Signed-off-by: MOVZX <movzx@yahoo.com>