### PR TITLE
Add 'Per-Quality Overrides' documentations

### DIFF
--- a/nvngx.ini
+++ b/nvngx.ini
@@ -36,13 +36,23 @@ UpscaleRatioOverrideEnabled=auto
 UpscaleRatioOverrideValue=auto
 
 [QualityOverrides]
+; Set custom upscaling ratio for each quality mode
+;
+; set this to true to enable custom quality mode overrides
 QualityRatioOverrideEnabled=auto
+;
+; Default values:
+; Ultra Quality         : 1.3
+; Quality               : 1.5
+; Balanced              : 1.7
+; Performance           : 2.0
+; Ultra Performance     : 3.0
+;
 QualityRatioUltraQuality=auto
 QualityRatioQuality=auto
 QualityRatioBalanced=auto
 QualityRatioPerformance=auto
 QualityRatioUltraPerformance=auto
-
 
 [View]
 ; config, cyberpunk2077 or rdr2


### PR DESCRIPTION
Set custom upscaling ratio for each quality mode

Default values:
Ultra Quality         : 1.3
Quality               : 1.5
Balanced              : 1.7
Performance           : 2.0
Ultra Performance     : 3.0

Signed-off-by: MOVZX <movzx@yahoo.com>