### PR TITLE
add CyberFsrDx11.cpp to .vcxproj and improvement to GetModule() function

### DIFF
--- a/CyberFSR/CyberFSR.vcxproj
+++ b/CyberFSR/CyberFSR.vcxproj
@@ -177,6 +177,7 @@
   <ItemGroup>
     <ClCompile Include="Config.cpp" />
     <ClCompile Include="CyberFsr.cpp" />
+    <ClCompile Include="CyberFsrDx11.cpp" />
     <ClCompile Include="CyberFsrDx12.cpp" />
     <ClCompile Include="CyberFsrVk.cpp" />
     <ClCompile Include="DebugOverlay.cpp" />

--- a/CyberFSR/CyberFSR.vcxproj.filters
+++ b/CyberFSR/CyberFSR.vcxproj.filters
@@ -83,5 +83,8 @@
     <ClCompile Include="scanner.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="CyberFsrDx11.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/CyberFSR/scanner.cpp
+++ b/CyberFSR/scanner.cpp
@@ -1,75 +1,75 @@
 #include "pch.h"
 #include "scanner.h"
 
-	std::pair<uintptr_t, uintptr_t> GetModule()
+std::pair<uintptr_t, uintptr_t> GetModule(const std::wstring_view moduleName)
+{
+	const static uintptr_t moduleBase = reinterpret_cast<uintptr_t>(GetModuleHandleW(moduleName.data()));
+	const static uintptr_t moduleEnd = [&]()
 	{
-			const static uintptr_t moduleBase = reinterpret_cast<uintptr_t>(GetModuleHandleW(NULL));
-			const static uintptr_t moduleEnd = [&]()
-			{
-				auto ntHeaders = reinterpret_cast<PIMAGE_NT_HEADERS64>(moduleBase + reinterpret_cast<PIMAGE_DOS_HEADER>(moduleBase)->e_lfanew);
-				return static_cast<uintptr_t>(moduleBase + ntHeaders->OptionalHeader.SizeOfImage);
-			}();
+		auto ntHeaders = reinterpret_cast<PIMAGE_NT_HEADERS64>(moduleBase + reinterpret_cast<PIMAGE_DOS_HEADER>(moduleBase)->e_lfanew);
+		return static_cast<uintptr_t>(moduleBase + ntHeaders->OptionalHeader.SizeOfImage);
+	}();
 
-			return { moduleBase, moduleEnd };
-	}
+	return { moduleBase, moduleEnd };
+}
 
 
-	uintptr_t FindPattern(uintptr_t startAddress, uintptr_t maxSize, const char* mask)
+uintptr_t FindPattern(uintptr_t startAddress, uintptr_t maxSize, const char* mask)
+{
+	std::vector<std::pair<uint8_t, bool>> pattern;
+
+	for (size_t i = 0; i < strlen(mask);)
 	{
-		std::vector<std::pair<uint8_t, bool>> pattern;
-
-		for (size_t i = 0; i < strlen(mask);)
+		if (mask[i] != '?')
 		{
-			if (mask[i] != '?')
-			{
-				pattern.emplace_back(static_cast<uint8_t>(strtoul(&mask[i], nullptr, 16)), false);
-				i += 3;
-			}
-			else
-			{
-				pattern.emplace_back(0x00, true);
-				i += 2;
-			}
+			pattern.emplace_back(static_cast<uint8_t>(strtoul(&mask[i], nullptr, 16)), false);
+			i += 3;
 		}
-
-		const auto dataStart = reinterpret_cast<const uint8_t*>(startAddress);
-		const auto dataEnd = dataStart + maxSize + 1;
-
-		auto sig = std::search(dataStart, dataEnd, pattern.begin(), pattern.end(),
-			[](uint8_t CurrentByte, std::pair<uint8_t, bool> Pattern)
-			{
-				return Pattern.second || (CurrentByte == Pattern.first);
-			});
-
-		if (sig == dataEnd)
-			return 0;
-
-		return std::distance(dataStart, sig) + startAddress;
-	}
-
-	uintptr_t scanner::GetAddress(const std::wstring_view moduleName, const std::string_view pattern, ptrdiff_t offset)
-	{
-		if (GetModuleHandleW(moduleName.data()) != nullptr)
+		else
 		{
-			uintptr_t address = FindPattern(GetModule().first, GetModule().second - GetModule().first, pattern.data());
-
-			if (address == 0)
-				throw std::runtime_error("Failed to find pattern");
-
-			return (address + offset);
+			pattern.emplace_back(0x00, true);
+			i += 2;
 		}
 	}
 
-	uintptr_t scanner::GetOffsetFromInstruction(const std::wstring_view moduleName, const std::string_view pattern, ptrdiff_t offset)
-	{
-		if (GetModuleHandleW(moduleName.data()) != nullptr)
+	const auto dataStart = reinterpret_cast<const uint8_t*>(startAddress);
+	const auto dataEnd = dataStart + maxSize + 1;
+
+	auto sig = std::search(dataStart, dataEnd, pattern.begin(), pattern.end(),
+		[](uint8_t currentByte, std::pair<uint8_t, bool> Pattern)
 		{
-			uintptr_t address = FindPattern(GetModule().first, GetModule().second - GetModule().first, pattern.data());
+			return Pattern.second || (currentByte == Pattern.first);
+		});
 
-			if (address == 0)
-				throw std::runtime_error("Failed to find pattern");
+	if (sig == dataEnd)
+		return NULL;
 
-			auto reloffset = *reinterpret_cast<int32_t*>(address + offset) + sizeof(int32_t);
-			return (address + offset + reloffset);
-		}
+	return std::distance(dataStart, sig) + startAddress;
+}
+
+uintptr_t scanner::GetAddress(const std::wstring_view moduleName, const std::string_view pattern, ptrdiff_t offset)
+{
+	if (GetModuleHandleW(moduleName.data()) != nullptr)
+	{
+		uintptr_t address = FindPattern(GetModule(moduleName.data()).first, GetModule(moduleName.data()).second - GetModule(moduleName.data()).first, pattern.data());
+
+		if (address == NULL)
+			throw std::runtime_error("Failed to find pattern");
+
+		return (address + offset);
 	}
+}
+
+uintptr_t scanner::GetOffsetFromInstruction(const std::wstring_view moduleName, const std::string_view pattern, ptrdiff_t offset)
+{
+	if (GetModuleHandleW(moduleName.data()) != nullptr)
+	{
+		uintptr_t address = FindPattern(GetModule(moduleName.data()).first, GetModule(moduleName.data()).second - GetModule(moduleName.data()).first, pattern.data());
+
+		if (address == NULL)
+			throw std::runtime_error("Failed to find pattern");
+
+		auto reloffset = *reinterpret_cast<int32_t*>(address + offset) + sizeof(int32_t);
+		return (address + offset + reloffset);
+	}
+}


### PR DESCRIPTION
-  add CyberFsrDx11.cpp to .vcxproj if compiled without it games like rise of tomb raider won't load nvgx.dll
-  improve GetModule() function for more sanity now it uses module name to get modulebase and module end in future this will help us to deal with games like DL2 and games where the main game is a .dll and the .exe is just a loader for everything