### PR TITLE
update RDR2 projection matrix offset

### DIFF
--- a/CyberFSR/ViewMatrixHook.cpp
+++ b/CyberFSR/ViewMatrixHook.cpp
@@ -83,7 +83,7 @@ float ViewMatrixHook::Cyberpunk2077::GetNearPlane()
 ViewMatrixHook::RDR2::RDR2()
 {
 	auto loc = scanner::GetOffsetFromInstruction(L"RDR2.exe", "4C 8D 2D ? ? ? ? 48 85 DB", 3);
-	camParams = (CameraParams*)loc;
+	camParams = ((CameraParams*)(loc + 0x60));
 }
 
 float ViewMatrixHook::RDR2::GetFov()


### PR DESCRIPTION
the pattern was correct, but offset was wrong which caused several visual glitches credits to @MOVZX for reporting, testing and sending me proper data to find this.
Edit: this should be compatible with any version staring from the version which added DLSS to the game.