### PR TITLE
some optimizations, enhancements and refactoring 

### DIFF
--- a/CyberFSR/CyberFSR.vcxproj
+++ b/CyberFSR/CyberFSR.vcxproj
@@ -131,6 +131,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/CyberFSR/CyberFsr.cpp
+++ b/CyberFSR/CyberFsr.cpp
@@ -4,19 +4,6 @@
 #include "DirectXHooks.h"
 #include "Util.h"
 
-NvParameter* CyberFsrContext::AllocateParameter()
-{
-	Parameters.push_back(std::make_unique<NvParameter>());
-	return Parameters.back().get();
-}
-
-void CyberFsrContext::DeleteParameter(NvParameter* parameter)
-{
-	auto it = std::find_if(Parameters.begin(), Parameters.end(),
-		[parameter](const auto& p) { return p.get() == parameter; });
-	Parameters.erase(it);
-}
-
 FeatureContext* CyberFsrContext::CreateContext()
 {
 	auto handleId = rand();

--- a/CyberFSR/CyberFsr.h
+++ b/CyberFSR/CyberFsr.h
@@ -17,9 +17,7 @@ public:
 	VkInstance VulkanInstance;
 	VkPhysicalDevice VulkanPhysicalDevice;
 
-	std::vector<std::unique_ptr<NvParameter>> Parameters;
-	NvParameter* AllocateParameter();
-	void DeleteParameter(NvParameter* parameter);
+	std::shared_ptr<NvParameter> NvParameterInstance = NvParameter::instance();
 
 	std::unordered_map <unsigned int, std::unique_ptr<FeatureContext>> Contexts;
 	FeatureContext* CreateContext();
@@ -27,7 +25,7 @@ public:
 
 	static std::shared_ptr<CyberFsrContext> instance()
 	{
-		static std::shared_ptr<CyberFsrContext> INSTANCE{new CyberFsrContext()};
+		static std::shared_ptr<CyberFsrContext> INSTANCE{std::make_shared<CyberFsrContext>(CyberFsrContext())};
 		return INSTANCE;
 	}
 };

--- a/CyberFSR/CyberFsrDx11.cpp
+++ b/CyberFSR/CyberFsrDx11.cpp
@@ -13,6 +13,6 @@ NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_D3D11_Shutdown(void)
 
 NVSDK_NGX_Result NVSDK_NGX_D3D11_GetParameters(NVSDK_NGX_Parameter** OutParameters)
 {
-	*OutParameters = CyberFsrContext::instance()->AllocateParameter();
+	*OutParameters = CyberFsrContext::instance()->NvParameterInstance->AllocateParameters();
 	return NVSDK_NGX_Result_Success;
 }

--- a/CyberFSR/CyberFsrDx12.cpp
+++ b/CyberFSR/CyberFsrDx12.cpp
@@ -28,43 +28,43 @@ NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_with_ProjectID(const char* InProjectId, NV
 
 NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_D3D12_Shutdown(void)
 {
-	CyberFsrContext::instance()->Parameters.clear();
+	CyberFsrContext::instance()->NvParameterInstance->Params.clear();
 	CyberFsrContext::instance()->Contexts.clear();
 	return NVSDK_NGX_Result_Success;
 }
 
 NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_D3D12_Shutdown1(ID3D12Device* InDevice)
 {
-	CyberFsrContext::instance()->Parameters.clear();
+	CyberFsrContext::instance()->NvParameterInstance->Params.clear();
 	CyberFsrContext::instance()->Contexts.clear();
 	return NVSDK_NGX_Result_Success;
 }
 
-//Deprecated Parameter Function - Internal Memory Tracking
+//currently it's kind of hack but better than what it was previously -- External Memory Tracking
 NVSDK_NGX_Result NVSDK_NGX_D3D12_GetParameters(NVSDK_NGX_Parameter** OutParameters)
 {
-	*OutParameters = CyberFsrContext::instance()->AllocateParameter();
+	*OutParameters = CyberFsrContext::instance()->NvParameterInstance->AllocateParameters();
 	return NVSDK_NGX_Result_Success;
 }
 
-//TODO External Memory Tracking
+//currently it's kind of hack still needs a proper implementation 
 NVSDK_NGX_Result NVSDK_NGX_D3D12_GetCapabilityParameters(NVSDK_NGX_Parameter** OutParameters)
 {
-	*OutParameters = new NvParameter();
+	*OutParameters = NvParameter::instance()->AllocateParameters();
 	return NVSDK_NGX_Result_Success;
 }
 
-//TODO
+//currently it's kind of hack still needs a proper implementation
 NVSDK_NGX_Result NVSDK_NGX_D3D12_AllocateParameters(NVSDK_NGX_Parameter** OutParameters)
 {
-	*OutParameters = new NvParameter();
+	*OutParameters = NvParameter::instance()->AllocateParameters();
 	return NVSDK_NGX_Result_Success;
 }
 
-//TODO
+//currently it's kind of hack still needs a proper implementation
 NVSDK_NGX_Result NVSDK_NGX_D3D12_DestroyParameters(NVSDK_NGX_Parameter* InParameters)
 {
-	delete InParameters;
+	NvParameter::instance()->DeleteParameters((NvParameter*)InParameters);
 	return NVSDK_NGX_Result_Success;
 }
 
@@ -78,13 +78,13 @@ NVSDK_NGX_Result NVSDK_NGX_D3D12_GetScratchBufferSize(NVSDK_NGX_Feature InFeatur
 NVSDK_NGX_Result NVSDK_NGX_D3D12_CreateFeature(ID3D12GraphicsCommandList* InCmdList, NVSDK_NGX_Feature InFeatureID,
 	const NVSDK_NGX_Parameter* InParameters, NVSDK_NGX_Handle** OutHandle)
 {
-	const auto inParams = dynamic_cast<const NvParameter*>(InParameters);
+	const auto inParams = NvParameter::instance()->Cast<const NvParameter*>(dynamic_cast<const NvParameter*>(InParameters));
 
 	ID3D12Device* device;
 	InCmdList->GetDevice(IID_PPV_ARGS(&device));
 
 	auto instance = CyberFsrContext::instance();
-	auto config = instance->MyConfig;
+	auto &config = instance->MyConfig;
 	auto deviceContext = CyberFsrContext::instance()->CreateContext();
 	deviceContext->ViewMatrix = ViewMatrixHook::Create(*config);
 #ifdef DEBUG_FEATURES
@@ -169,12 +169,12 @@ NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCommandList* InCm
 	ID3D12Device* device;
 	InCmdList->GetDevice(IID_PPV_ARGS(&device));
 	auto instance = CyberFsrContext::instance();
-	auto config = instance->MyConfig;
+	auto &config = instance->MyConfig;
 	auto deviceContext = CyberFsrContext::instance()->Contexts[InFeatureHandle->Id].get();
 
 	if (orgRootSig)
 	{
-		const auto inParams = dynamic_cast<const NvParameter*>(InParameters);
+		const auto inParams = NvParameter::instance()->Cast<const NvParameter*>(dynamic_cast<const NvParameter*>(InParameters)); 
 
 		auto* fsrContext = &deviceContext->FsrContext;
 

--- a/CyberFSR/CyberFsrDx12.cpp
+++ b/CyberFSR/CyberFsrDx12.cpp
@@ -78,7 +78,7 @@ NVSDK_NGX_Result NVSDK_NGX_D3D12_GetScratchBufferSize(NVSDK_NGX_Feature InFeatur
 NVSDK_NGX_Result NVSDK_NGX_D3D12_CreateFeature(ID3D12GraphicsCommandList* InCmdList, NVSDK_NGX_Feature InFeatureID,
 	const NVSDK_NGX_Parameter* InParameters, NVSDK_NGX_Handle** OutHandle)
 {
-	const auto inParams = NvParameter::instance()->Cast<const NvParameter*>(dynamic_cast<const NvParameter*>(InParameters));
+	const auto inParams = static_cast<const NvParameter*>(InParameters);
 
 	ID3D12Device* device;
 	InCmdList->GetDevice(IID_PPV_ARGS(&device));
@@ -174,7 +174,7 @@ NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCommandList* InCm
 
 	if (orgRootSig)
 	{
-		const auto inParams = NvParameter::instance()->Cast<const NvParameter*>(dynamic_cast<const NvParameter*>(InParameters)); 
+		const auto inParams = static_cast<const NvParameter*>(InParameters); 
 
 		auto* fsrContext = &deviceContext->FsrContext;
 

--- a/CyberFSR/CyberFsrVk.cpp
+++ b/CyberFSR/CyberFsrVk.cpp
@@ -80,7 +80,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_VULKAN_CreateFeature(VkComma
 
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_VULKAN_CreateFeature1(VkDevice InDevice, VkCommandBuffer InCmdList, NVSDK_NGX_Feature InFeatureID, const NVSDK_NGX_Parameter* InParameters, NVSDK_NGX_Handle** OutHandle)
 {
-	const auto inParams = NvParameter::instance()->Cast<const NvParameter*>(dynamic_cast<const NvParameter*>(InParameters));
+	const auto inParams = static_cast<const NvParameter*>(InParameters);
 
 	auto instance = CyberFsrContext::instance();
 	auto& config = instance->MyConfig;
@@ -153,7 +153,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_VULKAN_EvaluateFeature(VkCom
 	auto instance = CyberFsrContext::instance();
 	auto& config = instance->MyConfig;
 	auto deviceContext = CyberFsrContext::instance()->Contexts[InFeatureHandle->Id].get();
-	const auto inParams = NvParameter::instance()->Cast<const NvParameter*>(dynamic_cast<const NvParameter*>(InParameters));
+	const auto inParams = static_cast<const NvParameter*>(InParameters);
 
 	auto color = (NVSDK_NGX_Resource_VK*)inParams->Color;
 	auto depth = (NVSDK_NGX_Resource_VK*)inParams->Depth;

--- a/CyberFSR/CyberFsrVk.cpp
+++ b/CyberFSR/CyberFsrVk.cpp
@@ -27,7 +27,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_VULKAN_Shutdown(void)
 	CyberFsrContext::instance()->VulkanDevice = nullptr;
 	CyberFsrContext::instance()->VulkanInstance = nullptr;
 	CyberFsrContext::instance()->VulkanPhysicalDevice = nullptr;
-	CyberFsrContext::instance()->Parameters.clear();
+	CyberFsrContext::instance()->NvParameterInstance->Params.clear();
 	CyberFsrContext::instance()->Contexts.clear();
 	return NVSDK_NGX_Result_Success;
 }
@@ -37,32 +37,32 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_VULKAN_Shutdown1(VkDevice In
 	CyberFsrContext::instance()->VulkanDevice = nullptr;
 	CyberFsrContext::instance()->VulkanInstance = nullptr;
 	CyberFsrContext::instance()->VulkanPhysicalDevice = nullptr;
-	CyberFsrContext::instance()->Parameters.clear();
+	CyberFsrContext::instance()->NvParameterInstance->Params.clear();
 	CyberFsrContext::instance()->Contexts.clear();
 	return NVSDK_NGX_Result_Success;
 }
 
 NVSDK_NGX_Result NVSDK_NGX_VULKAN_GetParameters(NVSDK_NGX_Parameter** OutParameters)
 {
-	*OutParameters = CyberFsrContext::instance()->AllocateParameter();
+	*OutParameters = CyberFsrContext::instance()->NvParameterInstance->AllocateParameters();
 	return NVSDK_NGX_Result_Success;
 }
 
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_VULKAN_AllocateParameters(NVSDK_NGX_Parameter** OutParameters)
 {
-	*OutParameters = new NvParameter();
+	*OutParameters = NvParameter::instance()->AllocateParameters();
 	return NVSDK_NGX_Result_Success;
 }
 
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_VULKAN_GetCapabilityParameters(NVSDK_NGX_Parameter** OutParameters)
 {
-	*OutParameters = new NvParameter();
+	*OutParameters = NvParameter::instance()->AllocateParameters();
 	return NVSDK_NGX_Result_Success;
 }
 
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_VULKAN_DestroyParameters(NVSDK_NGX_Parameter* InParameters)
 {
-	delete InParameters;
+	NvParameter::instance()->DeleteParameters((NvParameter*)InParameters);
 	return NVSDK_NGX_Result_Success;
 }
 
@@ -80,7 +80,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_VULKAN_CreateFeature(VkComma
 
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_VULKAN_CreateFeature1(VkDevice InDevice, VkCommandBuffer InCmdList, NVSDK_NGX_Feature InFeatureID, const NVSDK_NGX_Parameter* InParameters, NVSDK_NGX_Handle** OutHandle)
 {
- 	const auto inParams = dynamic_cast<const NvParameter*>(InParameters);
+	const auto inParams = NvParameter::instance()->Cast<const NvParameter*>(dynamic_cast<const NvParameter*>(InParameters));
 
 	auto instance = CyberFsrContext::instance();
 	auto& config = instance->MyConfig;
@@ -153,7 +153,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_VULKAN_EvaluateFeature(VkCom
 	auto instance = CyberFsrContext::instance();
 	auto& config = instance->MyConfig;
 	auto deviceContext = CyberFsrContext::instance()->Contexts[InFeatureHandle->Id].get();
-	const auto inParams = dynamic_cast<const NvParameter*>(InParameters);
+	const auto inParams = NvParameter::instance()->Cast<const NvParameter*>(dynamic_cast<const NvParameter*>(InParameters));
 
 	auto color = (NVSDK_NGX_Resource_VK*)inParams->Color;
 	auto depth = (NVSDK_NGX_Resource_VK*)inParams->Depth;

--- a/CyberFSR/NvParameter.cpp
+++ b/CyberFSR/NvParameter.cpp
@@ -366,7 +366,7 @@ void NvParameter::EvaluateRenderScale()
 
 NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_DLSS_GetOptimalSettingsCallback(NVSDK_NGX_Parameter* InParams)
 {
-	auto* params = (NvParameter*)InParams;
+	auto params = NvParameter::instance()->Cast<NvParameter*>(dynamic_cast<NvParameter*>(InParams));
 	params->EvaluateRenderScale();
 	return NVSDK_NGX_Result_Success;
 }

--- a/CyberFSR/NvParameter.cpp
+++ b/CyberFSR/NvParameter.cpp
@@ -366,7 +366,7 @@ void NvParameter::EvaluateRenderScale()
 
 NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_DLSS_GetOptimalSettingsCallback(NVSDK_NGX_Parameter* InParams)
 {
-	auto params = NvParameter::instance()->Cast<NvParameter*>(dynamic_cast<NvParameter*>(InParams));
+	auto params = static_cast<NvParameter*>(InParams);
 	params->EvaluateRenderScale();
 	return NVSDK_NGX_Result_Success;
 }

--- a/CyberFSR/NvParameter.h
+++ b/CyberFSR/NvParameter.h
@@ -59,11 +59,13 @@ struct NvParameter : NVSDK_NGX_Parameter
 
 	void EvaluateRenderScale();
 
+	/**
 	template <typename T>
 	inline constexpr T& Cast(const auto& Parameter)
 	{
 		return *((T*)&Parameter);
 	}
+	**/
 
 	std::vector<std::shared_ptr<NvParameter>> Params;
 

--- a/CyberFSR/NvParameter.h
+++ b/CyberFSR/NvParameter.h
@@ -58,5 +58,31 @@ struct NvParameter : NVSDK_NGX_Parameter
 	NVSDK_NGX_Result Get_Internal(const char* InName, unsigned long long* OutValue, NvParameterType ParameterType) const;
 
 	void EvaluateRenderScale();
-};
 
+	template <typename T>
+	inline constexpr T& Cast(const auto& Parameter)
+	{
+		return *((T*)&Parameter);
+	}
+
+	std::vector<std::shared_ptr<NvParameter>> Params;
+
+	__declspec(noinline) NvParameter* AllocateParameters()
+	{
+		Params.push_back(std::make_shared<NvParameter>());
+		return Params.back().get();
+	}
+
+	__declspec(noinline) void DeleteParameters(NvParameter* param)
+	{
+		auto it = std::find_if(Params.begin(), Params.end(),
+			[param](const auto& p) { return p.get() == param; });
+		Params.erase(it);
+	}
+
+	static std::shared_ptr<NvParameter> instance()
+	{
+		static std::shared_ptr<NvParameter> INSTANCE { std::make_shared<NvParameter>() };
+		return INSTANCE;
+	}
+};

--- a/CyberFSR/ViewMatrixHook.cpp
+++ b/CyberFSR/ViewMatrixHook.cpp
@@ -83,7 +83,7 @@ float ViewMatrixHook::Cyberpunk2077::GetNearPlane()
 ViewMatrixHook::RDR2::RDR2()
 {
 	auto loc = scanner::GetOffsetFromInstruction(L"RDR2.exe", "4C 8D 2D ? ? ? ? 48 85 DB", 3);
-	camParams = (CameraParams*)loc;
+	camParams = ((CameraParams*)(loc + 0x60));
 }
 
 float ViewMatrixHook::RDR2::GetFov()


### PR DESCRIPTION
this PR does following things:

- creates and uses a shared Instance of **NvParameter** struct for Allocate and Destroy and GetParameters of DLSS which avoids using _new operator_ multiple times and this kind of properly destroys parameters in **NVSDK_NGX_DestroyParameters** function. the same instance is used globally for clearing and doing other parameter related stuff.
- now the **dynamic_cast**s of **NvParameter** or calls to **__RTDynamicCast** are also part of **NvParameter::instance()**.
- correct projection matrix offset for RDR2 it is (loc + 0x60) unironically same as Cyberpunk 2077.
