### PR TITLE
replace std::unordered_map with ankerl::unordered_dense::map

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "external/simpleini"]
 	path = external/simpleini
 	url = https://github.com/brofield/simpleini
+[submodule "external/unordered_dense"]
+	path = external/unordered_dense
+	url = https://github.com/martinus/unordered_dense.git

--- a/CyberFSR/CyberFSR.vcxproj
+++ b/CyberFSR/CyberFSR.vcxproj
@@ -77,11 +77,11 @@
     <IncludePath>$(SolutionDir)external\simpleini;$(SolutionDir)external\nvngx_dlss_sdk\include;$(SolutionDir)external\FidelityFX-FSR2\src;$(VULKAN_SDK)\Include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>$(SolutionDir)external\simpleini;$(SolutionDir)external\nvngx_dlss_sdk\include;$(SolutionDir)external\FidelityFX-FSR2\src;$(VULKAN_SDK)\Include;$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)external\simpleini;$(SolutionDir)external\nvngx_dlss_sdk\include;$(SolutionDir)external\unordered_dense\include;$(SolutionDir)external\FidelityFX-FSR2\src;$(VULKAN_SDK)\Include;$(IncludePath)</IncludePath>
     <LibraryPath>$(SolutionDir)external\FidelityFX-FSR2\bin\ffx_fsr2_api;$(VULKAN_SDK)\Lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>$(SolutionDir)external\simpleini;$(SolutionDir)external\nvngx_dlss_sdk\include;$(SolutionDir)external\FidelityFX-FSR2\src;$(VULKAN_SDK)\Include;$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)external\simpleini;$(SolutionDir)external\nvngx_dlss_sdk\include;$(SolutionDir)external\unordered_dense\include;$(SolutionDir)external\FidelityFX-FSR2\src;$(VULKAN_SDK)\Include;$(IncludePath)</IncludePath>
     <TargetName>nvngx</TargetName>
     <LibraryPath>$(SolutionDir)external\FidelityFX-FSR2\bin\ffx_fsr2_api;$(VULKAN_SDK)\Lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>

--- a/CyberFSR/CyberFsr.h
+++ b/CyberFSR/CyberFsr.h
@@ -21,7 +21,7 @@ public:
 	NvParameter* AllocateParameter();
 	void DeleteParameter(NvParameter* parameter);
 
-	std::unordered_map <unsigned int, std::unique_ptr<FeatureContext>> Contexts;
+	ankerl::unordered_dense::map <unsigned int, std::unique_ptr<FeatureContext>> Contexts;
 	FeatureContext* CreateContext();
 	void DeleteContext(NVSDK_NGX_Handle* handle);
 

--- a/CyberFSR/DirectXHooks.cpp
+++ b/CyberFSR/DirectXHooks.cpp
@@ -15,7 +15,7 @@ SETCOMPUTEROOTSIGNATURE oSetComputeRootSignature = nullptr;
 
 ID3D12CommandList* myCommandList = nullptr;
 
-std::unordered_map<ID3D12GraphicsCommandList*, ID3D12RootSignature*> commandListVector;
+ankerl::unordered_dense::map<ID3D12GraphicsCommandList*, ID3D12RootSignature*> commandListVector;
 
 std::mutex rootSigMutex;
 

--- a/CyberFSR/DirectXHooks.h
+++ b/CyberFSR/DirectXHooks.h
@@ -5,7 +5,7 @@ typedef void(__fastcall* SETCOMPUTEROOTSIGNATURE)(ID3D12GraphicsCommandList* com
 
 extern ID3D12CommandList* myCommandList;
 
-extern std::unordered_map<ID3D12GraphicsCommandList*, ID3D12RootSignature*> commandListVector;
+extern ankerl::unordered_dense::map<ID3D12GraphicsCommandList*, ID3D12RootSignature*> commandListVector;
 
 extern std::mutex rootSigMutex;
 

--- a/CyberFSR/Util.cpp
+++ b/CyberFSR/Util.cpp
@@ -77,7 +77,7 @@ float Util::ConvertSharpness(float sharpness, std::optional<SharpnessRangeModifi
 
 Util::NvParameter Util::NvParameterToEnum(const char* name)
 {
-	static std::unordered_map<std::string, NvParameter> NvParamTranslation = {
+	static ankerl::unordered_dense::map<std::string, NvParameter> NvParamTranslation = {
 		{"SuperSampling.ScaleFactor", NvParameter::SuperSampling_ScaleFactor},
 		{"SuperSampling.Available", NvParameter::SuperSampling_Available},
 		{"SuperSampling.MinDriverVersionMajor", NvParameter::SuperSampling_MinDriverVersionMajor},

--- a/CyberFSR/framework.h
+++ b/CyberFSR/framework.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
 #include <d3d12.h>
 #include <DirectXMath.h>
 #include <wrl/wrappers/corewrappers.h>
 #include <memory>
-#include <unordered_map>
 #include <vector>
 #include <mutex>
 #include <limits>
@@ -28,4 +28,5 @@
 #include <nvsdk_ngx.h>
 #include <nvsdk_ngx_vk.h>
 
+#include "..\external\unordered_dense\include\ankerl\unordered_dense.h"
 #include "SimpleIni.h"

--- a/CyberFSR/framework.h
+++ b/CyberFSR/framework.h
@@ -28,5 +28,5 @@
 #include <nvsdk_ngx.h>
 #include <nvsdk_ngx_vk.h>
 
-#include "..\external\unordered_dense\include\ankerl\unordered_dense.h"
-#include "SimpleIni.h"
+#include <ankerl/unordered_dense.h>
+#include <SimpleIni.h>

--- a/CyberFSR/scanner.cpp
+++ b/CyberFSR/scanner.cpp
@@ -72,4 +72,5 @@ uintptr_t scanner::GetOffsetFromInstruction(const std::wstring_view moduleName, 
 		auto reloffset = *reinterpret_cast<int32_t*>(address + offset) + sizeof(int32_t);
 		return (address + offset + reloffset);
 	}
+	throw std::runtime_error("Failed to find the module");
 }


### PR DESCRIPTION
i know this adds another dependency but compared to the STL std::unordered_map lookups are very fast and uses much less memory and CPU instructions.(from different tests this saves about 1.5x memory depending on various situations)