### PR TITLE
convert filename and exename to wstring and refactor some stuff inside DllMain

### DIFF
--- a/CyberFSR/Config.cpp
+++ b/CyberFSR/Config.cpp
@@ -2,7 +2,7 @@
 #include "Config.h"
 #include "Util.h"
 
-Config::Config(std::string fileName)
+Config::Config(std::wstring fileName)
 {
 	absoluteFileName = Util::DllPath().parent_path() / fileName;
 
@@ -56,15 +56,15 @@ void Config::Reload()
 
 	auto exeName = Util::ExePath().filename();
 
-	if (exeName == "Cyberpunk2077.exe")
+	if (exeName == L"Cyberpunk2077.exe")
 	{
 		Method = Method.value_or(ViewMethod::Cyberpunk2077);
 	}
-	else if (exeName == "DyingLightGame_x64_rwdi.exe")
+	else if (exeName == L"DyingLightGame_x64_rwdi.exe")
 	{
 		SharpnessRange = SharpnessRange.value_or(SharpnessRangeModifier::Extended);
 	}
-	else if (exeName == "RDR2.exe")
+	else if (exeName == L"RDR2.exe")
 	{
 		Method = Method.value_or(ViewMethod::RDR2);
 	}

--- a/CyberFSR/Config.h
+++ b/CyberFSR/Config.h
@@ -17,7 +17,7 @@ enum class ViewMethod
 class Config
 {
 public:
-	Config(std::string fileName);
+	Config(std::wstring fileName);
 
 	// Depth
 	std::optional<bool> DepthInverted;

--- a/CyberFSR/CyberFsr.cpp
+++ b/CyberFSR/CyberFsr.cpp
@@ -36,5 +36,5 @@ void CyberFsrContext::DeleteContext(NVSDK_NGX_Handle* handle)
 
 CyberFsrContext::CyberFsrContext()
 {
-	MyConfig = std::make_unique<Config>("nvngx.ini");
+	MyConfig = std::make_unique<Config>(L"nvngx.ini");
 }

--- a/CyberFSR/dllmain.cpp
+++ b/CyberFSR/dllmain.cpp
@@ -2,17 +2,18 @@
 
 HMODULE dllModule;
 
-BOOL APIENTRY DllMain( HMODULE hModule,
-                       DWORD  ul_reason_for_call,
-                       LPVOID lpReserved
-                     )
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
-    dllModule = hModule;
     switch (ul_reason_for_call)
     {
     case DLL_PROCESS_ATTACH:
+        DisableThreadLibraryCalls(hModule);
+        dllModule = hModule;
+        break;
     case DLL_THREAD_ATTACH:
+        break;
     case DLL_THREAD_DETACH:
+        break;
     case DLL_PROCESS_DETACH:
         break;
     }


### PR DESCRIPTION
- convert filename and exename to wchar_t just like we are doing with filepaths and and GetModuleHandleW
- refactor some stuff inside dllmain and call DisableThreadLibraryCalls after DLL_PROCESS_ATTACH